### PR TITLE
add a subset of HVAC_MODE_SETS

### DIFF
--- a/custom_components/localtuya/climate.py
+++ b/custom_components/localtuya/climate.py
@@ -94,6 +94,11 @@ HVAC_MODE_SETS = {
         HVACMode.COOL: "cold",
         HVACMode.AUTO: "auto",
     },
+    "Cold/Dehumidify/Hot": {
+        HVACMode.HEAT: "hot",
+        HVACMode.DRY: "dehumidify",
+        HVACMode.COOL: "cold",
+    },
     "1/0": {
         HVACMode.HEAT: "1",
         HVACMode.AUTO: "0",


### PR DESCRIPTION
iPAC-40 Portable Air Conditioning Heat Pump with Wifi and Remote Control. These devices have a limited option of modes. The available modes are Hot, Cold and Dry.

![iPAC-40-SET-1 -herojpg_7013316d-e786-45c6-8d70-a69db812ae10](https://github.com/user-attachments/assets/0d0d5f50-57d0-47ea-a6dc-fcaa90790c17)

![Screenshot_20241231_001708_Smart Life](https://github.com/user-attachments/assets/ad41176b-d734-4953-afe0-0a09ff979c5f)